### PR TITLE
Update arrayMethods.js

### DIFF
--- a/arrayMethods.js
+++ b/arrayMethods.js
@@ -99,7 +99,7 @@ inventors.sort((a, b) => {
 console.log(inventors);
 
 // KORTERE VERSIE (optioneel):
-// inventors.sort((a, b) => (a.passed - a.year) - (b.passed - b.year));
+// inventors.sort((a, b) => (b.passed - b.year) - (a.passed - a.year));
 
 // 6. Vind de gegevens over de uitvinder wiens achternaam 'Edison' is.
 // Verwachte uitkomst: { first: 'Thomas', last: 'Edison', year: 1847, passed: 1931 }


### PR DESCRIPTION
Er zat een klein foutje in opdracht 5 geloof ik. De kortere versie van de uitwerking moet het volgende zijn:

inventors.sort((a, b) => (b.passed - b.year) - (a.passed - a.year));

De conditie moet omgedraaid worden anders krijg je de inventor die het kortst heeft geleefd eerst. Maar check het vooral zelf nog even dubbel hoor.